### PR TITLE
Bootstrap Scripts

### DIFF
--- a/bootstrap-scalog.sh
+++ b/bootstrap-scalog.sh
@@ -1,0 +1,173 @@
+#!/bin/bash
+
+RED="\033[0;31m"
+GREEN="\033[1;32m"
+YELLOW="\033[1;33m"
+NC="\033[0m"
+
+echo -e "Scalog Install\n"
+echo "This script is meant to bootstrap a scalog cluster quickly on a cluster of machines. Within this cluster, we expect one machine to be used to bootstrap the kubernetes cluster, and all other machines should simply join this cluster."
+
+read -p $'\e[33mIs this the primary machine? (yes/no):\e[0m' isPrimary
+while ! [ "$isPrimary" =~ ^(yes|no)$ ]
+do
+  read -p $'\e[33mIs this the primary machine? (yes/no):\e[0m' isPrimary
+  echo -e "${RED}Enter a valid string${NC}"
+done 
+
+echo "Installing docker on this local machine"
+
+# Install Docker CE
+## Set up the repository:
+### Install packages to allow apt to use a repository over HTTPS
+sudo apt-get update > /dev/null 2>&1  && sudo apt-get install -y apt-transport-https ca-certificates curl software-properties-common > /dev/null 2>&1
+if [ $? -ne 0 ]
+then
+  echo -e "${RED}Failed to install apt-transport-https ca-certificates curl software-properties-common${NC}"
+  exit 1
+fi
+
+### Add Docker’s official GPG key
+(curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -) > /dev/null 2>&1
+if [ $? -ne 0 ]
+then
+  echo -e "${RED}Failed to add Docker's GPG key${NC}"
+  exit 1
+fi
+
+### Add Docker apt repository.
+sudo add-apt-repository \
+  "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
+  $(lsb_release -cs) \
+  stable"
+if [ $? -ne 0 ]
+then
+  echo -e "${RED}Failed to add Docker's apt repository${NC}"
+  exit 1
+fi
+
+## Install Docker CE.
+sudo apt-get update > /dev/null 2>&1 && sudo apt-get install -y docker-ce=18.06.2~ce~3-0~ubuntu > /dev/null 2>&1
+if [ $? -ne 0 ]
+then
+  echo -e "${RED}Failed to install Docker CE${NC}"
+  exit 1
+fi
+
+echo -e "${GREEN}Successfully installed Docker${NC}"
+echo "Installing kubeadm on this local machine..."
+
+sudo apt-get update > /dev/null 2>&1 && sudo apt-get install -y apt-transport-https curl > /dev/null 2>&1
+if [ $? -ne 0 ]
+then
+  echo -e "${RED}Failed to install apt-transport-https curl${NC}"
+  exit 1
+fi
+
+(curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -) > /dev/null 2>&1
+if [ $? -ne 0 ]
+then
+  echo -e "${RED}Failed to add kubeadm apt-key${NC}"
+  exit 1
+fi
+
+(echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee -a /etc/apt/sources.list.d/kubernetes.list) > /dev/null 2>&1
+if [ $? -ne 0 ]
+then
+  echo -e "${RED}Failed to set kubenretes repository${NC}"
+  exit 1
+fi
+
+sudo apt-get update > /dev/null 2>&1 && sudo apt-get install -y kubelet kubeadm kubectl > /dev/null 2>&1 && sudo apt-mark hold kubelet kubeadm kubectl > /dev/null 2>&1
+if [ $? -ne 0 ]
+then
+  echo -e "${RED}Failed to install kubeadm${NC}"
+  exit 1
+fi
+
+modprobe br_netfilter
+if [ $? -ne 0 ]
+then
+  echo -e "${RED}Failed modprobe br_netfilter${NC}"
+  exit 1
+fi
+
+sudo swapoff -a
+if [ $? -ne 0 ]
+then
+  echo -e "${RED}Failed to turn swap off${NC}"
+  exit 1
+fi
+
+echo -e "${GREEN}Successfully installed kubeadm!!!${NC}\n"
+
+if [ $isPrimary == "yes" ]
+then 
+  echo "Bootstrapping kubernetes cluster..."
+
+  kubeout=$(sudo kubeadm init --pod-network-cidr=10.244.0.0/16)
+  if [ $? -ne 0 ]
+  then
+    echo -e "${RED}Failed to bootstrap kubernetes cluster${NC}"
+    exit 1
+  fi
+
+  sudo cp /etc/kubernetes/admin.conf $HOME/ && sudo chown $(id -u):$(id -g) $HOME/admin.conf && export KUBECONFIG=$HOME/admin.conf  
+  if [ $? -ne 0 ]
+  then
+    echo -e "${RED}Failed to export KUBECONFIG${NC}"
+    exit 1
+  fi
+
+  # Create Pod Network Layer
+  kubectl apply -f https://raw.githubusercontent.com/coreos/flannel/a70459be0084506e4ec919aa1c114638878db11b/Documentation/kube-flannel.yml > /dev/null 2>&1
+  if [ $? -ne 0 ]
+  then
+    echo -e "${RED}Failed to create pod network layer for kubernetes${NC}"
+    exit 1
+  fi
+
+  echo -e $kubeout
+  echo -e "${GREEN}Kubernetes cluster successfully bootstrapped!${NC}"
+  echo -e "${YELLOW}Copy paste the kubeadm script output into the other servers in this cluster. It should look something like kubeadm join 130.127.133.78:6443 --token nrorf3.vdp46o3fa75ykvch \ --discovery-token-ca-cert-hash sha256:aeab241dce8a6d3eb9e0b6dc98aa39342357f9b3f204d281bb87e526afb4691a"
+  
+  read -p $'\e[33mPress enter when the other nodes have joined the cluster:\e[0m'
+
+  echo "Starting Scalog..."
+  echo -e "${YELLOW}Downloading Scalog packages...${NC}"
+  mkdir scalog
+  mkdir scalog/crds
+
+  wget -O scalog/namespace.yaml https://raw.githubusercontent.com/scalog/scalog/master/data/k8s/namespace.yaml
+  wget -O scalog/volumes.yaml https://raw.githubusercontent.com/scalog/scalog/master/data/k8s/volumes.yaml
+  wget -O scalog/rbac.yaml https://raw.githubusercontent.com/scalog/scalog/master/data/k8s/rbac.yaml
+
+  wget -O scalog/crds/scalog_v1alpha1_scalogservice_cr.yaml https://raw.githubusercontent.com/scalog/scalog-operator/master/deploy/crds/scalog_v1alpha1_scalogservice_cr.yaml
+  wget -O scalog/crds/scalog_v1alpha1_scalogservice_crd.yaml https://raw.githubusercontent.com/scalog/scalog-operator/master/deploy/crds/scalog_v1alpha1_scalogservice_crd.yaml
+  wget -O scalog/operator.yaml https://raw.githubusercontent.com/scalog/scalog-operator/master/deploy/operator.yaml
+  wget -O scalog/op-rbac.yaml https://raw.githubusercontent.com/scalog/scalog-operator/master/deploy/rbac.yaml
+  wget -O scalog/op-role.yaml https://raw.githubusercontent.com/scalog/scalog-operator/master/deploy/role.yaml
+  wget -O scalog/op-rb.yaml https://raw.githubusercontent.com/scalog/scalog-operator/master/deploy/role_binding.yaml
+  wget -O scalog/op-sa.yaml https://raw.githubusercontent.com/scalog/scalog-operator/master/deploy/service_account.yaml
+
+  echo -e "${GREEN}Successfully downloaded Scalog packages${NC}"
+  echo "Starting Scalog Services..."
+
+  kubectl create -f scalog/namespace.yaml
+  kubectl create -f scalog/volumes.yaml
+  kubectl create -f scalog/rbac.yaml
+
+  kubectl create -f scalog/op-sa.yaml
+  kubectl create -f scalog/op-role.yaml
+  kubectl create -f scalog/op-rb.yaml
+  kubectl create -f scalog/op-rbac.yaml
+  kubectl create -f scalog/crds/scalog_v1alpha1_scalogservice_crd.yaml
+  kubectl create -f scalog/operator.yaml
+  kubectl create -f scalog/crds/scalog_v1alpha1_scalogservice_cr.yaml
+
+else 
+  # Follower
+  echo -e "${YELLOW}Copy and paste the kubeadm join script received from the primary machine. It should look something like: kubeadm join 130.127.133.78:6443 --token nrorf3.vdp46o3fa75ykvch --discovery-token-ca-cert-hash sha256:aeab241dce8a6d3eb9e0b6dc98aa39342357f9b3f204d281bb87e526afb4691a. It helps if you put sudo before it.${NC}"
+fi
+
+echo -e "${GREEN}Success!${NC}"

--- a/debug-bootstrap-scalog.sh
+++ b/debug-bootstrap-scalog.sh
@@ -5,22 +5,19 @@ GREEN="\033[1;32m"
 YELLOW="\033[1;33m"
 NC="\033[0m"
 
-echo -e "Scalog Install\n"
-echo "This script is meant to bootstrap a scalog cluster quickly on a cluster of machines. Within this cluster, we expect one machine to be used to bootstrap the kubernetes cluster, and all other machines should simply join this cluster."
-
 read -p $'\e[33mIs this the primary machine? (yes/no):\e[0m' isPrimary
 while ! [[ "$isPrimary" =~ ^(yes|no)$ ]]
 do
   read -p $'\e[33mIs this the primary machine? (yes/no):\e[0m' isPrimary
   echo -e "${RED}Enter a valid string${NC}"
-done 
+done
 
 echo "Installing docker on this local machine"
 
 # Install Docker CE
 ## Set up the repository:
 ### Install packages to allow apt to use a repository over HTTPS
-sudo apt-get update > /dev/null 2>&1  && sudo apt-get install -y apt-transport-https ca-certificates curl software-properties-common > /dev/null 2>&1
+sudo apt-get update && sudo apt-get install -y apt-transport-https ca-certificates curl software-properties-common
 if [ $? -ne 0 ]
 then
   echo -e "${RED}Failed to install apt-transport-https ca-certificates curl software-properties-common${NC}"
@@ -28,7 +25,7 @@ then
 fi
 
 ### Add Docker’s official GPG key
-(curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -) > /dev/null 2>&1
+(curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -)
 if [ $? -ne 0 ]
 then
   echo -e "${RED}Failed to add Docker's GPG key${NC}"
@@ -47,7 +44,7 @@ then
 fi
 
 ## Install Docker CE.
-sudo apt-get update > /dev/null 2>&1 && sudo apt-get install -y docker-ce=18.06.2~ce~3-0~ubuntu > /dev/null 2>&1
+sudo apt-get update && sudo apt-get install -y docker-ce=18.06.2~ce~3-0~ubuntu
 if [ $? -ne 0 ]
 then
   echo -e "${RED}Failed to install Docker CE${NC}"
@@ -57,28 +54,28 @@ fi
 echo -e "${GREEN}Successfully installed Docker${NC}"
 echo "Installing kubeadm on this local machine..."
 
-sudo apt-get update > /dev/null 2>&1 && sudo apt-get install -y apt-transport-https curl > /dev/null 2>&1
+sudo apt-get update && sudo apt-get install -y apt-transport-https curl
 if [ $? -ne 0 ]
 then
   echo -e "${RED}Failed to install apt-transport-https curl${NC}"
   exit 1
 fi
 
-(curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -) > /dev/null 2>&1
+(curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -)
 if [ $? -ne 0 ]
 then
   echo -e "${RED}Failed to add kubeadm apt-key${NC}"
   exit 1
 fi
 
-(echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee -a /etc/apt/sources.list.d/kubernetes.list) > /dev/null 2>&1
+(echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee -a /etc/apt/sources.list.d/kubernetes.list)
 if [ $? -ne 0 ]
 then
   echo -e "${RED}Failed to set kubenretes repository${NC}"
   exit 1
 fi
 
-sudo apt-get update > /dev/null 2>&1 && sudo apt-get install -y kubelet kubeadm kubectl > /dev/null 2>&1 && sudo apt-mark hold kubelet kubeadm kubectl > /dev/null 2>&1
+sudo apt-get update && sudo apt-get install -y kubelet kubeadm kubectl && sudo apt-mark hold kubelet kubeadm kubectl
 if [ $? -ne 0 ]
 then
   echo -e "${RED}Failed to install kubeadm${NC}"
@@ -102,7 +99,7 @@ fi
 echo -e "${GREEN}Successfully installed kubeadm!!!${NC}\n"
 
 if [ $isPrimary == "yes" ]
-then 
+then
   echo "Bootstrapping kubernetes cluster..."
 
   kubeout=$(sudo kubeadm init --pod-network-cidr=10.244.0.0/16)
@@ -120,7 +117,7 @@ then
   fi
 
   # Create Pod Network Layer
-  kubectl apply -f https://raw.githubusercontent.com/coreos/flannel/a70459be0084506e4ec919aa1c114638878db11b/Documentation/kube-flannel.yml > /dev/null 2>&1
+  kubectl apply -f https://raw.githubusercontent.com/coreos/flannel/a70459be0084506e4ec919aa1c114638878db11b/Documentation/kube-flannel.yml
   if [ $? -ne 0 ]
   then
     echo -e "${RED}Failed to create pod network layer for kubernetes${NC}"
@@ -130,7 +127,7 @@ then
   echo -e $kubeout
   echo -e "${GREEN}Kubernetes cluster successfully bootstrapped!${NC}"
   echo -e "${YELLOW}Copy paste the kubeadm script output into the other servers in this cluster. It should look something like kubeadm join 130.127.133.78:6443 --token nrorf3.vdp46o3fa75ykvch \ --discovery-token-ca-cert-hash sha256:aeab241dce8a6d3eb9e0b6dc98aa39342357f9b3f204d281bb87e526afb4691a"
-  
+
   read -p $'\e[33mPress enter when the other nodes have joined the cluster:\e[0m'
 
   echo "Starting Scalog..."
@@ -165,7 +162,7 @@ then
   kubectl create -f scalog/operator.yaml
   kubectl create -f scalog/crds/scalog_v1alpha1_scalogservice_cr.yaml
 
-else 
+else
   # Follower
   echo -e "${YELLOW}Copy and paste the kubeadm join script received from the primary machine. It should look something like: kubeadm join 130.127.133.78:6443 --token nrorf3.vdp46o3fa75ykvch --discovery-token-ca-cert-hash sha256:aeab241dce8a6d3eb9e0b6dc98aa39342357f9b3f204d281bb87e526afb4691a. It helps if you put sudo before it.${NC}"
 fi

--- a/install_scripts/bootstrap.sh
+++ b/install_scripts/bootstrap.sh
@@ -6,9 +6,10 @@ echo "Bootstrapping kubernetes cluster..."
 sudo kubeadm init --pod-network-cidr=10.244.0.0/16
 
 # Change permissions, so kubectl can run as a normal user
-sudo cp /etc/kubernetes/admin.conf $HOME/
-sudo chown $(id -u):$(id -g) $HOME/admin.conf
-export KUBECONFIG=$HOME/admin.conf
+mkdir -p $HOME/.kube
+sudo cp -i /etc/kubernetes/admin.conf $HOME/.kube/config
+sudo chown $(id -u):$(id -g) $HOME/.kube/config
 
 # Create Pod Network Layer
 kubectl apply -f https://raw.githubusercontent.com/coreos/flannel/a70459be0084506e4ec919aa1c114638878db11b/Documentation/kube-flannel.yml
+  

--- a/install_scripts/bootstrap.sh
+++ b/install_scripts/bootstrap.sh
@@ -1,11 +1,14 @@
 #!/bin/bash
-echo "Bootstrapping kubernetes cluster"
-kubeadm init --pod-network-cidr=10.244.0.0/16
 
-# Create Pod Network Layer
-kubectl apply -f https://raw.githubusercontent.com/coreos/flannel/a70459be0084506e4ec919aa1c114638878db11b/Documentation/kube-flannel.yml
+echo "Bootstrapping kubernetes cluster..."
+
+# Initiate kubernetes cluster
+sudo kubeadm init --pod-network-cidr=10.244.0.0/16
 
 # Change permissions, so kubectl can run as a normal user
 sudo cp /etc/kubernetes/admin.conf $HOME/
 sudo chown $(id -u):$(id -g) $HOME/admin.conf
 export KUBECONFIG=$HOME/admin.conf
+
+# Create Pod Network Layer
+kubectl apply -f https://raw.githubusercontent.com/coreos/flannel/a70459be0084506e4ec919aa1c114638878db11b/Documentation/kube-flannel.yml


### PR DESCRIPTION
The original bootstrapping scripts have been left in their respective folders -- I've created two additional files in the root directory to avoid confusion, `bootstrap-scalog.sh` and `debug-bootstrap-scalog.sh`. These are both meant to be run with `bash`, not `sh`, since on Ubuntu `sh` invokes `dash` I believe, which is less feature rich. The debug version outputs all command results.